### PR TITLE
fix: Twitter link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -10,7 +10,7 @@
 [![ReVanced Discord](https://user-images.githubusercontent.com/13122796/178032563-d4e084b7-244e-4358-af50-26bde6dd4996.png)](https://revanced.app/discord)
 [![ReVanced Reddit](https://user-images.githubusercontent.com/13122796/178032351-9d9d5619-8ef7-470a-9eec-2744ece54553.png)](https://reddit.com/r/revancedapp)
 [![ReVanced Telegram](https://user-images.githubusercontent.com/13122796/178032213-faf25ab8-0bc3-4a94-a730-b524c96df124.png)](https://t.me/app_revanced)
-[![ReVanced Twitter](https://user-images.githubusercontent.com/13122796/178032018-6da37214-7474-4641-a1da-7af7db3a31cd.png)](https://twitter/revancedapp)
+[![ReVanced Twitter](https://user-images.githubusercontent.com/13122796/178032018-6da37214-7474-4641-a1da-7af7db3a31cd.png)](https://twitter.com/revancedapp)
 [![ReVanced YouTube](https://user-images.githubusercontent.com/13122796/178032714-c51c7492-0666-44ac-99c2-f003a695ab50.png)](https://www.youtube.com/c/ReVanced)
 
 # ♥️ ReVanced Contributors


### PR DESCRIPTION
Twitter link should be https://twitter.com/revancedapp instead of https://twitter/revancedapp