### PR TITLE
fix: update youtube link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -31,7 +31,7 @@
    <a href="https://twitter.com/revancedapp">
        <img height="24px" src="https://user-images.githubusercontent.com/13122796/178032018-6da37214-7474-4641-a1da-7af7db3a31cd.png" />
    </a>&nbsp;&nbsp;&nbsp;
-   <a href="https://www.youtube.com/channel/UCLktAUh5Gza9zAJBStwxNdw">
+   <a href="https://youtube.com/@ReVanced">
        <img height="24px" src="https://user-images.githubusercontent.com/13122796/178032714-c51c7492-0666-44ac-99c2-f003a695ab50.png" />
    </a>&nbsp;&nbsp;&nbsp;
    <br>


### PR DESCRIPTION
The link points to a non existing channel. This has been updated to https://youtube.com/@ReVanced.