### PR TITLE
feat: Add global discussion config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🗨 Discussions
+    url: https://github.com/revanced/revanced-suggestions/discussions
+    about: Have something unspecific to ReVanced in mind? Search for or start a new discussion!


### PR DESCRIPTION
Add a generic discussion to avoid committing config repeatedly for each new ReVanced repository.

side-effect is that you have to copy this configuration and add on to the config whenever you need to edit something to fit your repository's needs