### PR TITLE
Add other type of donation to funding.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
 github: ReVanced
 open_collective: ReVanced
+custom: [https://revanced.app/donate]


### PR DESCRIPTION
Cryptocurrency donating is missing from the list, this might be an awkward way to do this because the link leads to all three methods of donation. https://revanced.app/donate#cryptocurrencies would be correct way to do this.